### PR TITLE
test-pkg-cloud

### DIFF
--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -1,0 +1,106 @@
+package cloud
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDetectRegion(t *testing.T) {
+	tests := []struct {
+		name string
+		node *v1.Node
+		want string
+	}{
+		{
+			name: "base",
+			node: &v1.Node{},
+			want: "",
+		},
+		{
+			name: "qcloud with no node labels",
+			node: &v1.Node{
+				Spec: v1.NodeSpec{
+					ProviderID: "qcloud://01",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "qcloud with node labels",
+			node: &v1.Node{
+				Spec: v1.NodeSpec{
+					ProviderID: "qcloud://01",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.LabelTopologyRegion: "gz",
+					},
+				},
+			},
+			want: "ap-guangzhou",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectRegion(tt.node); got != tt.want {
+				t.Errorf("DetectRegion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		node *v1.Node
+		want ProviderKind
+	}{
+		{
+			name: "base",
+			node: &v1.Node{},
+			want: "default",
+		},
+		{
+			name: "qcloud",
+			node: &v1.Node{
+				Spec: v1.NodeSpec{
+					ProviderID: "qcloud://01",
+				},
+			},
+			want: "qcloud",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectProvider(tt.node); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DetectProvider() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewProviderConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		customPricing *CustomPricing
+		want          *PriceConfig
+	}{
+		{
+			name:          "base",
+			customPricing: &CustomPricing{},
+			want: &PriceConfig{
+				customPricing: &CustomPricing{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewProviderConfig(tt.customPricing); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewProviderConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: jxs1211 <327411586@qq.com>

Description
ut

Related Issues
N/A

New Behavior (screenshots if needed)
PS D:\shen\go\open_source\fadvisor\pkg\cloud> go test -v -cover
=== RUN   TestDetectRegion
=== RUN   TestDetectRegion/base
=== RUN   TestDetectRegion/qcloud_with_no_node_labels
=== RUN   TestDetectRegion/qcloud_with_node_labels
--- PASS: TestDetectRegion (0.00s)
    --- PASS: TestDetectRegion/base (0.00s)
    --- PASS: TestDetectRegion/qcloud_with_no_node_labels (0.00s)
    --- PASS: TestDetectRegion/qcloud_with_node_labels (0.00s)
=== RUN   TestDetectProvider
=== RUN   TestDetectProvider/base
=== RUN   TestDetectProvider/qcloud
--- PASS: TestDetectProvider (0.00s)
    --- PASS: TestDetectProvider/base (0.00s)
    --- PASS: TestDetectProvider/qcloud (0.00s)
=== RUN   TestNewProviderConfig
=== RUN   TestNewProviderConfig/base
--- PASS: TestNewProviderConfig (0.00s)
    --- PASS: TestNewProviderConfig/base (0.00s)
=== RUN   TestPriceConfig_GetConfig
=== RUN   TestPriceConfig_GetConfig/base
--- PASS: TestPriceConfig_GetConfig (0.00s)
    --- PASS: TestPriceConfig_GetConfig/base (0.00s)
PASS
coverage: 22.4% of statements
ok      github.com/gocrane/fadvisor/pkg/cloud   1.394s
PS D:\shen\go\open_source\fadvisor\pkg\cloud>