### PR TITLE
test-pkg-cloud-plugins

### DIFF
--- a/pkg/cloud/plugins_test.go
+++ b/pkg/cloud/plugins_test.go
@@ -1,0 +1,146 @@
+package cloud
+
+import (
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gocrane/fadvisor/pkg/cache"
+)
+
+func TestRegisterCloudProvider(t *testing.T) {
+	defer func() {
+		// clear up
+		defer providersMutex.Unlock()
+		providers = make(map[ProviderKind]Factory)
+	}()
+	RegisterCloudProvider(TencentCloud, mockFactory)
+	providersMutex.Lock()
+	_, ok := providers[TencentCloud]
+	if !ok {
+		t.Errorf("RegisterCloudProvider() = not found registered cloud")
+	}
+}
+
+type mockCloud struct {
+	Cloud
+}
+
+type mockCache struct {
+	cache.Cache
+}
+
+func mockFactory(cloudConfig io.Reader, priceConfig *PriceConfig, cache *cache.Cache) (Cloud, error) {
+	return mockCloud{}, nil
+}
+
+func TestGetCloudProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		kindName    ProviderKind
+		cloudConfig io.Reader
+		priceConfig *PriceConfig
+		cache       cache.Cache
+		want        Cloud
+		wantErr     bool
+		PreRegister bool
+	}{
+		{
+			name:     "base",
+			kindName: TencentCloud,
+			cache:    mockCache{},
+		},
+		{
+			name:        "found provider by name",
+			kindName:    TencentCloud,
+			cloudConfig: strings.NewReader("test"),
+			priceConfig: &PriceConfig{},
+			cache:       mockCache{},
+			want:        mockCloud{},
+			wantErr:     false,
+			PreRegister: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				// clear up
+				providersMutex.Lock()
+				defer providersMutex.Unlock()
+				providers = make(map[ProviderKind]Factory)
+			}()
+			if tt.PreRegister {
+				RegisterCloudProvider(tt.kindName, mockFactory)
+			}
+			got, err := GetCloudProvider(tt.kindName, tt.cloudConfig, tt.priceConfig, &tt.cache)
+			gotErr := (err != nil)
+			if gotErr != tt.wantErr {
+				t.Errorf("GetCloudProvider() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCloudProvider() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInitCloudProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		kindName    ProviderKind
+		CloudOpts   CloudConfig
+		priceConfig *PriceConfig
+		cache       cache.Cache
+		want        Cloud
+		wantErr     bool
+		PreRegister bool
+	}{
+		{
+			name: "base",
+			CloudOpts: CloudConfig{
+				CloudConfigFile: t.TempDir(),
+				Provider:        string(TencentCloud),
+			},
+			wantErr: true,
+		},
+		{
+			name:      "not CloudConfigFile and cloud is nil",
+			CloudOpts: CloudConfig{},
+			wantErr:   true,
+		},
+		{
+			name:     "base",
+			kindName: TencentCloud,
+			CloudOpts: CloudConfig{
+				Provider: string(TencentCloud),
+			},
+			want:        mockCloud{},
+			wantErr:     false,
+			PreRegister: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				// clear up
+				providersMutex.Lock()
+				defer providersMutex.Unlock()
+				providers = make(map[ProviderKind]Factory)
+			}()
+			if tt.PreRegister {
+				RegisterCloudProvider(tt.kindName, mockFactory)
+			}
+			got, err := InitCloudProvider(tt.CloudOpts, tt.priceConfig, &tt.cache)
+			gotErr := (err != nil)
+			if gotErr != tt.wantErr {
+				t.Errorf("InitCloudProvider() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("InitCloudProvider() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: jxs1211 <327411586@qq.com>

Description
ut

Related Issues
N/A

New Behavior (screenshots if needed)
PS D:\shen\go\open_source\fadvisor\pkg\cloud> go test -v -cover
=== RUN TestRegisterCloudProvider
=== RUN TestRegisterCloudProvider/base
--- PASS: TestRegisterCloudProvider (0.00s)
--- PASS: TestRegisterCloudProvider/base (0.00s)
=== RUN TestGetCloudProvider
=== RUN TestGetCloudProvider/base
=== RUN TestGetCloudProvider/found_provider_by_name
--- PASS: TestGetCloudProvider (0.00s)
--- PASS: TestGetCloudProvider/base (0.00s)
--- PASS: TestGetCloudProvider/found_provider_by_name (0.00s)
=== RUN TestInitCloudProvider
=== RUN TestInitCloudProvider/base
=== RUN TestInitCloudProvider/not_CloudConfigFile_and_cloud_is_nil
=== RUN TestInitCloudProvider/base#01
--- PASS: TestInitCloudProvider (0.01s)
--- PASS: TestInitCloudProvider/base (0.00s)
--- PASS: TestInitCloudProvider/not_CloudConfigFile_and_cloud_is_nil (0.00s)
--- PASS: TestInitCloudProvider/base#01 (0.00s)
PASS
coverage: 35.8% of statements